### PR TITLE
VRCSDK が存在しない場合に Compile error が発生する

### DIFF
--- a/Packages/com.ramtype0.meshia.mesh-simplification/Ndmf/Runtime/NDMFMeshSimplifier.cs
+++ b/Packages/com.ramtype0.meshia.mesh-simplification/Ndmf/Runtime/NDMFMeshSimplifier.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
+#if ENABLE_VRCHAT_BASE
 using VRC.SDKBase;
+#endif
 
 
 namespace Meshia.MeshSimplification.Ndmf

--- a/Packages/com.ramtype0.meshia.mesh-simplification/Ndmf/Runtime/NDMFMeshSimplifier.cs
+++ b/Packages/com.ramtype0.meshia.mesh-simplification/Ndmf/Runtime/NDMFMeshSimplifier.cs
@@ -1,7 +1,4 @@
 using UnityEngine;
-#if ENABLE_VRCHAT_BASE
-using VRC.SDKBase;
-#endif
 
 
 namespace Meshia.MeshSimplification.Ndmf
@@ -10,7 +7,7 @@ namespace Meshia.MeshSimplification.Ndmf
     [RequireComponent(typeof(Renderer))]
     public class NdmfMeshSimplifier : MonoBehaviour
 #if ENABLE_VRCHAT_BASE
-    , IEditorOnly
+    , VRC.SDKBase.IEditorOnly
 #endif
     {
         public MeshSimplificationTarget target = new()


### PR DESCRIPTION
適当に クローンして起動したら、 VRCSDK を入れておらずコンパイルエラーが発生したのですが ... 
インターフェースの部分は #if されているので VRCSDK なしでも動作できるのが正常で、 using の部分の #if を忘れてしまっていると考えるのが正しいように思えたので、その using の部分に #if を追加する PR です！