### PR TITLE
Try supporting overlapped vertex buffer and index buffer between sub meshes

### DIFF
--- a/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/CollectVertexSubMeshIndexesJob.cs
+++ b/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/CollectVertexSubMeshIndexesJob.cs
@@ -1,0 +1,29 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace Meshia.MeshSimplification
+{
+    [BurstCompile]
+    struct CollectVertexSubMeshIndexesJob : IJobParallelFor
+    {
+        [ReadOnly] public Mesh.MeshData Mesh;
+
+        [WriteOnly] public NativeArray<uint> VertexSubMeshIndexes;
+
+        public void Execute(int vertexIndex)
+        {
+            ref var vertexSubMeshIndex = ref VertexSubMeshIndexes.ElementAt(vertexIndex);
+            vertexSubMeshIndex = 0u;
+            for (int i = 0; i < Mesh.subMeshCount; i++)
+            {
+                var subMesh = Mesh.GetSubMesh(i);
+                if (subMesh.firstVertex <= vertexIndex && vertexIndex < subMesh.firstVertex + subMesh.vertexCount)
+                {
+                    vertexSubMeshIndex |= 1u << i;
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/CollectVertexSubMeshIndexesJob.cs.meta
+++ b/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/CollectVertexSubMeshIndexesJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f095b4a3d6c82064989f78a6a072f5c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/ExecuteProgressiveMeshSimplifyJob.cs
+++ b/Packages/com.ramtype0.meshia.mesh-simplification/Runtime/Jobs/ExecuteProgressiveMeshSimplifyJob.cs
@@ -28,6 +28,7 @@ namespace Meshia.MeshSimplification
         public NativeArray<float4> VertexTexCoord7Buffer;
         public NativeArray<float> VertexBlendWeightBuffer;
         public NativeArray<uint> VertexBlendIndicesBuffer;
+        public NativeArray<uint> VertexSubMeshIndexes;
         public NativeList<BlendShapeData> BlendShapes;
         public NativeArray<int3> Triangles;
         public NativeArray<ErrorQuadric> VertexErrorQuadrics;
@@ -62,6 +63,7 @@ namespace Meshia.MeshSimplification
                 VertexBlendIndicesBuffer = VertexBlendIndicesBuffer,
                 BlendShapes = BlendShapes,
                 Triangles = Triangles,
+                VertexSubMeshIndexes = VertexSubMeshIndexes,
                 VertexVersions = vertexVersions,
                 VertexErrorQuadrics = VertexErrorQuadrics,
                 VertexContainingTriangles = VertexContainingTriangles,


### PR DESCRIPTION
This PR attempting to fix the issue described in #4.

What I've done here:
- Implemented a vertex to sub mesh lookup array (With bit flags).
- When merging vertexes, instead of mapping destination sub mesh index to source index in sub mesh basis (which will process the overlapped vertexes more than once), now we do it in a whole.
- Vertex index range per sub meshes are calculated with the lookup array previously created.
- (Triangle) Index buffer size now been calculates with per sub mesh, since this buffer also allowed to overlapped with others. This approach may still generate duplicated triangles in the data, but this will make sure they are correctly mapped.