### PR TITLE
表示される文言を調整

### DIFF
--- a/Editor/Localization/Locales/en.po
+++ b/Editor/Localization/Locales/en.po
@@ -6,31 +6,37 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.label
 msgstr "Preserve Border Edges"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.tooltip"
-msgstr "If you want to suppress hole generation during simplification, enable this option."
+msgstr ""
+"Avoid removing edges that do not touch other surfaces, such as holes or cross sections.\n"
+"If you want to suppress hole generation during simplification, enable this option."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.label"
 msgstr "Preserve Surface Curvature"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.tooltip"
-msgstr "Change the cost formula to preserve gently curved surfaces."
+msgstr "Use a process that preserves gently curved surfaces, but sometimes the results can be worse."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateInterpolation.label"
 msgstr "Use Barycentric Coordinate Interpolation"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateInterpolation.tooltip"
-msgstr "If you find that the texture is distorted, try toggling this option."
+msgstr ""
+"Use Barycentric Coordinate Interpolation instead of linear interpolation for interpolating UVs, etc.\n"
+"If you find that the texture is distorted, try toggling this option."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.label"
-msgstr "Min Normal Dot"
+msgstr "Tolerance for Normal Angle (by cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.tooltip"
-msgstr "Specifies how much normal misalignment to allow when generating lightweight polygons.For example, cos90°=0 allows up to 90° displacement, and cos180°=-1 allows up to 180° displacement."
+msgstr ""
+"Specifies how much normal misalignment to allow when generating lightweight polygons.\n"
+"For example, 0(=cos90°) allows up to 90° misalignment, and -1(=cos180°) allows up to 180° misalignment."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.label"
 msgstr "Enable Smart Link"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.tooltip"
-msgstr "If this option is enabled, vertices that are not originally connected but are close to each other will be included in the first merge candidates. Increases the initialization cost."
+msgstr "If this option is enabled, vertices that are not originally connected but are close to each other will be included in the first merge candidates. Increases the processing time."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.SmartLinkOptions"
 msgstr "Smart Link Options"
@@ -39,25 +45,31 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.label"
 msgstr "Vertex Link Distance"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.tooltip"
-msgstr "When smart link is enabled, this is used to select candidates for merging vertices that are not originally connected to each other. Increasing this value also increases the initialization cost."
+msgstr ""
+"This value is used to select candidates for merging vertices that are not originally connected to each other, based on their position proximity.\n"
+"Larger values may increase processing time and crashes with meshes having more than 40,000 vertices."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.label"
 msgstr "Vertex Link Color Distance"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.tooltip"
-msgstr "Larger values may improve the shape of the polygons after lightening, but at the cost of unnatural vertex colors."
+msgstr ""
+"This value is used to select candidates for merging vertices that are not originally connected to each other, based on their vertex color similarity.\n"
+"Larger values may improve the shape of the polygons after lightening, but sometimes result in unnatural vertex colors instead."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.label"
 msgstr "Vertex Link UV Distance"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.tooltip"
-msgstr "Larger values may improve the shape of the polygons after lightening, but at the cost of making the UVs unnatural."
+msgstr ""
+"This value is used to select candidates for merging vertices that are not originally connected to each other, based on their UV coordinate proximity.\n"
+"Larger values may improve the shape of the polygons after lightening, but sometimes result in unnatural UVs instead."
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.label"
-msgstr "Vertex Link Min Normal Dot"
+msgstr "Tolerance for Normal Angle (by cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.tooltip"
-msgstr "Use different min normal dot for smart link. The more stringent of the two is used for smart link."
+msgstr "Use different tolerance for normal angle for Smart Link. The stricter of the two is used for Smart Link."
 
 msgid "locale:en"
 msgstr "English"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -11,10 +11,10 @@ msgstr ""
 "軽量化後のメッシュに穴が目立つ場合、このオプションを有効にしてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.label"
-msgstr "曲面を保持"
+msgstr "なだらかな曲面を保持"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.tooltip"
-msgstr "なだらかな曲面を維持するような計算式に変更します。"
+msgstr "なだらかな曲面を保持する処理を用いるようにしますが、結果が悪化する場合もあります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateInterpolation.label"
 msgstr "重心座標系補間を使用する"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -21,7 +21,7 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateI
 msgstr "UVなどの補間において、線形補間の代わりに重心座標系補間を用います。UVの歪みが目立つ場合、このオプションを切り替えてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.label"
-msgstr "許容法線最小角度誤差(cosθ)"
+msgstr "許容法線角度誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.tooltip"
 msgstr ""
@@ -59,7 +59,7 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.tool
 msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりにUVが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.label"
-msgstr "許容法線最小角度誤差(cosθ)"
+msgstr "許容法線角度誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.tooltip"
 msgstr "SmartLink処理時に、通常と異なる許容法線最小角度誤差を指定できます。2つのうち、厳しい方の値が適用されます。"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -29,7 +29,7 @@ msgstr ""
 "0(=cos90°)を指定すると90°までのズレを、-1(=cos180°)を指定すると180°までのズレを許容します。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.label"
-msgstr "近くの頂点同士をマージ候補に含める(Smart Link)"
+msgstr "近くの頂点同士をマージ候補に含める(SmartLink)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.tooltip"
 msgstr "同一のポリゴンに含まれている頂点に加えて、近くにある頂点同士も初期のマージ候補に含めるようにします。"
@@ -59,10 +59,10 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.tool
 msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりにUVが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.label"
-msgstr "許容法線角度誤差(cosθ)"
+msgstr "法線角度の許容誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.tooltip"
-msgstr "SmartLink処理時に、通常と異なる許容法線最小角度誤差を指定できます。2つのうち、厳しい方の値が適用されます。"
+msgstr "SmartLink処理時に、通常と異なる許容誤差を指定できます。2つのうち、厳しい方の値が適用されます。"
 
 msgid "locale:ja"
 msgstr "日本語"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -21,7 +21,7 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateI
 msgstr "UVなどの補間において、線形補間の代わりに重心座標系補間を用います。UVの歪みが目立つ場合、このオプションを切り替えてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.label"
-msgstr "許容する法線の最小角度差(cosX°の値で指定)"
+msgstr "許容法線最小角度誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.tooltip"
 msgstr ""
@@ -29,39 +29,40 @@ msgstr ""
 "0(=cos90°)を指定すると90°までのズレを、-1(=cos180°)を指定すると180°までのズレを許容します。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.label"
-msgstr "近くの頂点を統合候補に含める(Smart Link)"
+msgstr "近くの頂点同士をマージ候補に含める(Smart Link)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.tooltip"
-msgstr "同一のポリゴンに含まれている頂点に加えて、近くにある頂点も初めの統合候補に含めるようにします。"
+msgstr "同一のポリゴンに含まれている頂点に加えて、近くにある頂点同士も初期のマージ候補に含めるようにします。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.SmartLinkOptions"
 msgstr "SmartLink設定"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.label"
-msgstr "統合候補に含める頂点の距離"
+msgstr "マージ候補に含める頂点同士の距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.tooltip"
 msgstr ""
-"この距離より近い頂点が統合候補に含まれます。\n"
-"大きな値を設定すると処理時間が伸びる場合があります。"
+"この距離より近い頂点同士がマージ候補に含まれます。\n"
+"大きな値を設定すると処理時間が伸びる場合があります。\n"
+"また、4万頂点以上のメッシュで大きな値を指定するとクラッシュする場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.label"
-msgstr "統合候補に含める頂点カラーの距離"
+msgstr "マージ候補に含める頂点同士の頂点カラーの距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.tooltip"
 msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりに頂点カラーが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.label"
-msgstr "統合候補に含める頂点のUV距離"
+msgstr "マージ候補に含める頂点同士のUV距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.tooltip"
 msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりにUVが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.label"
-msgstr "許容する法線の最小角度差(cosX°の値で指定)"
+msgstr "許容法線最小角度誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.tooltip"
-msgstr "SmartLink処理時に、通常と異なる最小角度差を指定できます。2つのうち、厳しい方の値が適用されます。"
+msgstr "SmartLink処理時に、通常と異なる許容法線最小角度誤差を指定できます。2つのうち、厳しい方の値が適用されます。"
 
 msgid "locale:ja"
 msgstr "日本語"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -3,7 +3,7 @@ msgstr ""
 "Language: ja\n"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.label"
-msgstr "メッシュ外周の辺を保持"
+msgstr "メッシュの端の辺を保持"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.tooltip"
 msgstr ""

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -35,7 +35,7 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.tooltip"
 msgstr "同一のポリゴンに含まれている頂点に加えて、近くにある頂点も初めの統合候補に含めるようにします。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.SmartLinkOptions"
-msgstr "Smart Linkのオプション"
+msgstr "SmartLink設定"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.label"
 msgstr "統合候補に含める頂点の距離"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -3,61 +3,65 @@ msgstr ""
 "Language: ja\n"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.label"
-msgstr "端の露出したポリゴンを保持"
+msgstr "メッシュ外周の辺を保持"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.tooltip"
-msgstr "軽量化後のメッシュに穴が目立つとき、有効化してみてください。"
+msgstr "軽量化後のメッシュに穴が目立つ場合、このオプションを有効にしてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.label"
 msgstr "曲面を保持"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.tooltip"
-msgstr "なだらかな曲面を保持するようにコスト計算式を変更します。"
+msgstr "なだらかな曲面を維持するような計算式に変更します。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateInterpolation.label"
 msgstr "重心座標系補間を使用する"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateInterpolation.tooltip"
-msgstr "UVなどの補間に線形補間の代わりに重心座標系補間を用います。UVの歪みが目立つとき、切り替えてみてください。"
+msgstr "UVなどの補間において、線形補間の代わりに重心座標系補間を用います。UVの歪みが目立つ場合、このオプションを切り替えてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.label"
-msgstr "許容最小法線ドット積"
+msgstr "許容する法線の最小角度差(cosX°の値で指定)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.tooltip"
-msgstr "頂点を削減して軽量化されたポリゴンを生成する際、どこまで法線方向のズレを許容するかを指定します。たとえばcos90°=0を指定すると90°までのズレを許容し、cos180°=-1を指定することで180°までのズレを許容します。"
+msgstr ""
+"軽量化後のポリゴンにおいて、頂点の法線方向のズレをどこまで許容するか指定します。\n"
+"0(=cos90°)を指定すると90°までのズレを、-1(=cos180°)を指定すると180°までのズレを許容します。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.label"
-msgstr "近傍頂点をマージ候補に含める"
+msgstr "近くの頂点を統合候補に含める(Smart Link)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.EnableSmartLink.tooltip"
-msgstr "元々同一ポリゴンに含まれる頂点同士に加え、近傍頂点同士を初期のマージ候補に加えます。"
+msgstr "同一のポリゴンに含まれている頂点に加えて、近くにある頂点も初めの統合候補に含めるようにします。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.SmartLinkOptions"
-msgstr "近傍頂点マージオプション"
+msgstr "Smart Linkのオプション"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.label"
-msgstr "近傍頂点マージ距離"
+msgstr "統合候補に含める頂点の距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkDistance.tooltip"
-msgstr "この距離より近い頂点同士が近傍頂点とみなされ、マージ候補に加えられます。大きな値を設定すると、処理時間が伸びる場合があります。"
+msgstr ""
+"この距離より近い頂点が統合候補に含まれます。\n"
+"大きな値を設定すると処理時間が伸びる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.label"
-msgstr "近傍頂点マージ頂点カラー距離"
+msgstr "統合候補に含める頂点カラーの距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkColorDistance.tooltip"
-msgstr "大きな値を設定するほど軽量化後のポリゴンの形状が改善される場合がありますが、その代わりに頂点カラーが不自然になる場合があります。"
+msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりに頂点カラーが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.label"
-msgstr "近傍頂点マージ頂点UV距離"
+msgstr "統合候補に含める頂点のUV距離"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkUvDistance.tooltip"
-msgstr "大きな値を設定するほど軽量化後のポリゴンの形状が改善される場合がありますが、その代わりにUVが不自然になる場合があります。"
+msgstr "大きな値を設定すると軽量化後のポリゴンの形状が改善されることがありますが、代わりにUVが不自然になる場合があります。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.label"
-msgstr "近傍頂点マージ許容最小法線ドット積"
+msgstr "許容する法線の最小角度差(cosX°の値で指定)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.VertexLinkMinNormalDot.tooltip"
-msgstr "近傍頂点マージ時に異なる許容最小法線ドット積を使用します。2つのうち、より厳しいほうが近傍頂点マージ時に使用されます。"
+msgstr "SmartLink処理時に、通常と異なる最小角度差を指定できます。2つのうち、厳しい方の値が適用されます。"
 
 msgid "locale:ja"
 msgstr "日本語"

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -21,7 +21,7 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.UseBarycentricCoordinateI
 msgstr "UVなどの補間において、線形補間の代わりに重心座標系補間を用います。UVの歪みが目立つ場合、このオプションを切り替えてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.label"
-msgstr "許容法線角度誤差(cosθ)"
+msgstr "法線角度の許容誤差(cosθ)"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.MinNormalDot.tooltip"
 msgstr ""

--- a/Editor/Localization/Locales/ja.po
+++ b/Editor/Localization/Locales/ja.po
@@ -6,7 +6,9 @@ msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.label
 msgstr "メッシュ外周の辺を保持"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveBorderEdges.tooltip"
-msgstr "軽量化後のメッシュに穴が目立つ場合、このオプションを有効にしてみてください。"
+msgstr ""
+"他の面に接していない辺(穴や切れ目の縁など)を削除しないようにします。\n"
+"軽量化後のメッシュに穴が目立つ場合、このオプションを有効にしてみてください。"
 
 msgid "Meshia.MeshSimplification.MeshSimplifierOptions.PreserveSurfaceCurvature.label"
 msgstr "曲面を保持"


### PR DESCRIPTION
提案の側面が強いです。
本来専門性の高い内容ではあると思いますが、NDMF Previewによって結果が目に見えやすいこともあるため、ある程度分かりやすい文言にして調整しやすくする狙いもあります。

- [x] English
- [x] 日本語