### PR TITLE
ci: Add missing bd_ repo

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -76,8 +76,11 @@ jobs:
      - name: Setup vrc-get
        uses: anatawa12/sh-actions/setup-vrc-get@master
        
-     - name: Add VPM repositories
+     - name: Add Ram.Type-0 VPM repo
        run: vrc-get repo add https://ramtype0.github.io/VpmRepository/index.json
+       
+     - name: Add bd_ VPM repo
+       run: vrc-get repo add https://vpm.nadena.dev/vpm.json
        
      - name: Install VPM packages
        working-directory: ${{ env.PROJECT_PATH }}


### PR DESCRIPTION
Since I removed NDMF from Ram.Type-0 VPM repository, we need to reference bd_'s repo in ci.